### PR TITLE
feat: Project setup with Xcode, HealthKit, and directory structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,139 @@
+# マラソントレーニング管理アプリ - 開発ルール
+
+## ブランチ戦略
+
+```
+main ← develop ← feature/issue-XX-description
+```
+
+- **main**: 本番デプロイ用。developからのマージのみ
+- **develop**: 開発統合ブランチ。全feature PRのマージ先
+- **feature/issue-XX-***: 各issue用の作業ブランチ。developから切る
+
+## 開発フロー
+
+### 0. 実装前の準備（★ 必須）
+**issueに着手する前に、必ず以下を読んで内容を把握すること:**
+1. `docs/implementation-plan.md` — 実装計画の全体像（アーキテクチャ、データモデル、コード例）
+2. 対象issueの本文 — `gh issue view XX` で詳細を確認
+3. 依存issueが完了済みか確認
+
+これにより、実装計画の設計意図（Clean Architecture、SwiftData、HealthKit連携等）を理解した上でコードを書く。
+
+### 1. ブランチ作成
+```bash
+git fetch origin main develop
+# ★ mainの差分をdevelopに自動マージ（ズレ防止）
+git checkout develop
+git pull origin develop
+git merge origin/main --no-edit  # mainに差分があればマージ、なければno-op
+git push origin develop
+git checkout -b feature/issue-XX-description
+```
+
+### 2. 実装 → コミット → PR作成
+- issue番号を参照してコミットメッセージを書く（例: `feat: add HealthKit service (#3)`）
+- PRは **develop** ブランチに対して作成する
+- PR本文にはissue番号をリンク（`Closes #3`）
+
+### 3. Codex CLIでレビュー（自動）
+**PR作成後、確認なしで即座に `/codex-review PR番号` を実行すること。**ユーザーに「レビューしますか？」と聞かない。
+
+これにより:
+1. Codex CLIが実装計画 + issue内容を読み取ってからレビュー
+2. レビュー結果を `gh pr comment` でPRコメントに投稿
+3. 指摘があれば自動修正 → 再レビュー（最大3回ループ）
+
+### 4. レビュー指摘の修正
+- Codexの指摘をもとに**同じブランチで修正コミット**を追加
+- push後、**必ず再度Codexレビューを実行**する
+- **✅ LGTM が出るまでマージしない**（⚠️ や ❌ の状態でマージは禁止）
+- LGTM → マージの順序を厳守
+
+### 5. マージ → issueクローズ → 次のissueへ
+```bash
+gh pr merge PR番号 --merge
+gh issue close XX           # ★ マージ完了後、対応issueを必ずクローズする
+git checkout develop
+git pull origin develop
+# 次のissueのブランチを作成
+git checkout -b feature/issue-YY-description
+```
+
+### 6. develop → main のマージ（リリース時）
+一連のissueが完了したらdevelopをmainにマージ:
+```bash
+gh pr create --base main --head develop --title "release: Marathon Training App v1.0"
+```
+
+## issue実行順序
+
+| 順 | Issue | 内容 | 依存 |
+|----|-------|------|------|
+| 1 | #1 | プロジェクトセットアップ（Xcode, HealthKit Capability, ディレクトリ構造） | なし |
+| 2 | #2 | データモデル設計・実装（SwiftData: Race, TrainingMenu, Goal） | #1 |
+| 3 | #3 | HealthKit連携 - ランニングデータ取得 | #1 |
+| 4 | #4 | HealthKit連携 - 睡眠データ取得 | #1, #3 |
+| 5 | #10 | タブナビゲーション実装（Tab enum, ContentView） | #1 |
+| 6 | #5 | ホーム画面実装（CountdownCard, WeeklySummary, TodayMenu） | #2, #3, #4, #10 |
+| 7 | #6 | 週間メニュー画面実装（WeekCalendar, テンプレート機能） | #2, #10 |
+| 8 | #7 | 記録画面実装（ランニング履歴, 睡眠履歴, Charts） | #3, #4, #10 |
+| 9 | #8 | 目標管理画面実装（大会一覧, 週間目標, 長期目標） | #2, #10 |
+| 10 | #9 | 設定画面実装（HealthKit状態, 通知, プロフィール） | #3, #10 |
+
+詳細: [docs/implementation-plan.md](docs/implementation-plan.md)
+
+## コーディング規約
+
+- 言語: Swift
+- フレームワーク: SwiftUI, SwiftData, HealthKit, Charts
+- アーキテクチャ: Clean Architecture + MVVM
+- Minimum deployment target: iOS 17.0
+- ViewModelは `@Observable` マクロを使用
+- HealthKitは `async/await` で実装
+- 日本語UIテキスト、コード・コメントは英語
+- 既存コンポーネントのパターンを踏襲する
+
+## ディレクトリ構造
+
+```
+MarathonTraining/
+├── MarathonTrainingApp.swift
+├── App/
+│   ├── AppContainer.swift
+│   └── ContentView.swift
+├── Domain/
+│   ├── Entities/
+│   │   ├── RunningWorkout.swift
+│   │   └── SleepRecord.swift
+│   └── UseCases/
+├── Data/
+│   ├── Models/
+│   │   ├── RaceModel.swift
+│   │   ├── TrainingMenuModel.swift
+│   │   ├── WeeklyGoalModel.swift
+│   │   └── LongTermGoalModel.swift
+│   ├── Repositories/
+│   └── Services/
+│       └── HealthKit/
+│           └── HealthKitService.swift
+├── Presentation/
+│   ├── Home/
+│   ├── WeeklyMenu/
+│   ├── Records/
+│   ├── Goals/
+│   ├── Settings/
+│   └── Shared/
+└── Resources/
+```
+
+## 技術スタック
+
+| 技術 | 用途 |
+|-----|------|
+| iOS 17.0+ | 最小対応バージョン |
+| Swift | 開発言語 |
+| SwiftUI | UIフレームワーク |
+| SwiftData | データ永続化 |
+| HealthKit | ヘルスケアデータ取得 |
+| Charts | グラフ表示 |

--- a/MarathonTraining.xcodeproj/project.pbxproj
+++ b/MarathonTraining.xcodeproj/project.pbxproj
@@ -1,0 +1,432 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3DB311A0352E874807F280CA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6B615920679A5B6425AAFA /* SettingsView.swift */; };
+		48E5757A14DA59F1CC8E4E95 /* RecordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */; };
+		5DE1FB967AB7507E5415A297 /* WeeklyMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953436DD6951BDD71CAC756E /* WeeklyMenuView.swift */; };
+		86DFF99EC3386ECE483DAD6B /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7233A3B17BACE09E4F6B2D06 /* HomeView.swift */; };
+		BC3A8373A1CE6681F0FF20F2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3FBAFFDFA992C9C292C673C7 /* Assets.xcassets */; };
+		E01EB93515BC732201678B26 /* GoalsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56431ECF8DF3CECF3383E87 /* GoalsView.swift */; };
+		E9F02FA4336A69B219B9BE5E /* MarathonTrainingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1BFDF85EC77EAD3C6E91D /* MarathonTrainingApp.swift */; };
+		F3E16B53FAB717B0E0C99EE0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA174E98F44AB02D9C7696E1 /* ContentView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		1AD7264A823F71D85F424F2C /* MarathonTraining.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MarathonTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FBAFFDFA992C9C292C673C7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordsView.swift; sourceTree = "<group>"; };
+		60E1BFDF85EC77EAD3C6E91D /* MarathonTrainingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarathonTrainingApp.swift; sourceTree = "<group>"; };
+		7233A3B17BACE09E4F6B2D06 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		86EC631FD4930C1584D894B9 /* MarathonTraining.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MarathonTraining.entitlements; sourceTree = "<group>"; };
+		953436DD6951BDD71CAC756E /* WeeklyMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyMenuView.swift; sourceTree = "<group>"; };
+		AA174E98F44AB02D9C7696E1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		D433E722CA64B2DF5ECD787E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		DC6B615920679A5B6425AAFA /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		F56431ECF8DF3CECF3383E87 /* GoalsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalsView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		07028002A9871E89AD0F4342 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				C5C8FB43B80493EC99EC6911 /* Goals */,
+				757886FF777B674F109B31F0 /* Home */,
+				64757CBF1002F200C9690665 /* Records */,
+				D3A648F76330DAEF6E324CF8 /* Settings */,
+				590DD3DD9DFC98381AC510BC /* WeeklyMenu */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		25B6CCF6EB6F39567667AF8D = {
+			isa = PBXGroup;
+			children = (
+				B5A93E0A4DB18478FAF556E8 /* MarathonTraining */,
+				83459FD216897C553CCCFA76 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		590DD3DD9DFC98381AC510BC /* WeeklyMenu */ = {
+			isa = PBXGroup;
+			children = (
+				953436DD6951BDD71CAC756E /* WeeklyMenuView.swift */,
+			);
+			path = WeeklyMenu;
+			sourceTree = "<group>";
+		};
+		64757CBF1002F200C9690665 /* Records */ = {
+			isa = PBXGroup;
+			children = (
+				5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */,
+			);
+			path = Records;
+			sourceTree = "<group>";
+		};
+		757886FF777B674F109B31F0 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				7233A3B17BACE09E4F6B2D06 /* HomeView.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		83459FD216897C553CCCFA76 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1AD7264A823F71D85F424F2C /* MarathonTraining.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B5A93E0A4DB18478FAF556E8 /* MarathonTraining */ = {
+			isa = PBXGroup;
+			children = (
+				86EC631FD4930C1584D894B9 /* MarathonTraining.entitlements */,
+				60E1BFDF85EC77EAD3C6E91D /* MarathonTrainingApp.swift */,
+				FE1FF95FBE70827C5297B302 /* App */,
+				07028002A9871E89AD0F4342 /* Presentation */,
+				EA072B55E1B91217068D38E6 /* Resources */,
+			);
+			path = MarathonTraining;
+			sourceTree = "<group>";
+		};
+		C5C8FB43B80493EC99EC6911 /* Goals */ = {
+			isa = PBXGroup;
+			children = (
+				F56431ECF8DF3CECF3383E87 /* GoalsView.swift */,
+			);
+			path = Goals;
+			sourceTree = "<group>";
+		};
+		D3A648F76330DAEF6E324CF8 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				DC6B615920679A5B6425AAFA /* SettingsView.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		EA072B55E1B91217068D38E6 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				3FBAFFDFA992C9C292C673C7 /* Assets.xcassets */,
+				D433E722CA64B2DF5ECD787E /* Info.plist */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		FE1FF95FBE70827C5297B302 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				AA174E98F44AB02D9C7696E1 /* ContentView.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		"TEMP_1215615B-5A50-4C50-9179-05A73B19E72B" /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		"TEMP_214AD32D-9949-4B33-BEE2-CC8ECFE1D65E" /* Services */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		"TEMP_32A8BB60-4452-4BED-8933-B1356171060A" /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		"TEMP_D6A30078-7E44-494E-A48D-9EA84848D96A" /* Data */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Data;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		29C75AB470362CEC5E59C003 /* MarathonTraining */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C7E3940F45D4D58B6EA36C5F /* Build configuration list for PBXNativeTarget "MarathonTraining" */;
+			buildPhases = (
+				AFFBDCAF784BD999D5AD265E /* Sources */,
+				ADEF5C6CFDF44A0E747D9F23 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MarathonTraining;
+			packageProductDependencies = (
+			);
+			productName = MarathonTraining;
+			productReference = 1AD7264A823F71D85F424F2C /* MarathonTraining.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		76CB8A127519B4C1804C72FB /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					29C75AB470362CEC5E59C003 = {
+						SystemCapabilities = {
+							com.apple.HealthKit = {
+								enabled = YES;
+							};
+						};
+					};
+				};
+			};
+			buildConfigurationList = 651EC27035B9E1051877F475 /* Build configuration list for PBXProject "MarathonTraining" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 25B6CCF6EB6F39567667AF8D;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				29C75AB470362CEC5E59C003 /* MarathonTraining */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		ADEF5C6CFDF44A0E747D9F23 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BC3A8373A1CE6681F0FF20F2 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AFFBDCAF784BD999D5AD265E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F3E16B53FAB717B0E0C99EE0 /* ContentView.swift in Sources */,
+				E01EB93515BC732201678B26 /* GoalsView.swift in Sources */,
+				86DFF99EC3386ECE483DAD6B /* HomeView.swift in Sources */,
+				E9F02FA4336A69B219B9BE5E /* MarathonTrainingApp.swift in Sources */,
+				48E5757A14DA59F1CC8E4E95 /* RecordsView.swift in Sources */,
+				3DB311A0352E874807F280CA /* SettingsView.swift in Sources */,
+				5DE1FB967AB7507E5415A297 /* WeeklyMenuView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		0AE5D4B8DE21EEBD65E81352 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.9;
+			};
+			name = Debug;
+		};
+		61ED9DB03C3C54CA8FF63609 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = MarathonTraining/MarathonTraining.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = MarathonTraining/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.MarathonTraining;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A6DF51CF77D93CF995F921D6 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MARKETING_VERSION = 1.0.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.9;
+			};
+			name = Release;
+		};
+		EB846B95323E699DABBA4C43 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = MarathonTraining/MarathonTraining.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = MarathonTraining/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.MarathonTraining;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		651EC27035B9E1051877F475 /* Build configuration list for PBXProject "MarathonTraining" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0AE5D4B8DE21EEBD65E81352 /* Debug */,
+				A6DF51CF77D93CF995F921D6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C7E3940F45D4D58B6EA36C5F /* Build configuration list for PBXNativeTarget "MarathonTraining" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				61ED9DB03C3C54CA8FF63609 /* Debug */,
+				EB846B95323E699DABBA4C43 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 76CB8A127519B4C1804C72FB /* Project object */;
+}

--- a/MarathonTraining/App/ContentView.swift
+++ b/MarathonTraining/App/ContentView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        // Tab navigation will be implemented in Issue #10
+        Text("Marathon Training App")
+            .font(.title)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/MarathonTraining/MarathonTraining.entitlements
+++ b/MarathonTraining/MarathonTraining.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.healthkit</key>
+    <true/>
+    <key>com.apple.developer.healthkit.access</key>
+    <array/>
+</dict>
+</plist>

--- a/MarathonTraining/MarathonTrainingApp.swift
+++ b/MarathonTraining/MarathonTrainingApp.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import SwiftData
+
+@main
+struct MarathonTrainingApp: App {
+    var sharedModelContainer: ModelContainer = {
+        let schema = Schema([
+            // Models will be added here
+        ])
+        let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+
+        do {
+            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+        } catch {
+            fatalError("Could not create ModelContainer: \(error)")
+        }
+    }()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .modelContainer(sharedModelContainer)
+    }
+}

--- a/MarathonTraining/Presentation/Goals/GoalsView.swift
+++ b/MarathonTraining/Presentation/Goals/GoalsView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct GoalsView: View {
+    var body: some View {
+        Text("Goals")
+    }
+}
+
+#Preview {
+    GoalsView()
+}

--- a/MarathonTraining/Presentation/Home/HomeView.swift
+++ b/MarathonTraining/Presentation/Home/HomeView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        Text("Home")
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/MarathonTraining/Presentation/Records/RecordsView.swift
+++ b/MarathonTraining/Presentation/Records/RecordsView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct RecordsView: View {
+    var body: some View {
+        Text("Records")
+    }
+}
+
+#Preview {
+    RecordsView()
+}

--- a/MarathonTraining/Presentation/Settings/SettingsView.swift
+++ b/MarathonTraining/Presentation/Settings/SettingsView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        Text("Settings")
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/MarathonTraining/Presentation/WeeklyMenu/WeeklyMenuView.swift
+++ b/MarathonTraining/Presentation/WeeklyMenu/WeeklyMenuView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct WeeklyMenuView: View {
+    var body: some View {
+        Text("Weekly Menu")
+    }
+}
+
+#Preview {
+    WeeklyMenuView()
+}

--- a/MarathonTraining/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/MarathonTraining/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MarathonTraining/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/MarathonTraining/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MarathonTraining/Resources/Assets.xcassets/Contents.json
+++ b/MarathonTraining/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/MarathonTraining/Resources/Info.plist
+++ b/MarathonTraining/Resources/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSHealthShareUsageDescription</key>
+	<string>トレーニング記録と睡眠データを表示するために、ヘルスケアデータへのアクセスが必要です。</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,48 @@
+name: MarathonTraining
+options:
+  bundleIdPrefix: com.example
+  deploymentTarget:
+    iOS: "17.0"
+  xcodeVersion: "15.0"
+
+settings:
+  base:
+    SWIFT_VERSION: "5.9"
+    GENERATE_INFOPLIST_FILE: YES
+    CURRENT_PROJECT_VERSION: 1
+    MARKETING_VERSION: 1.0.0
+
+targets:
+  MarathonTraining:
+    type: application
+    platform: iOS
+    sources:
+      - MarathonTraining
+    settings:
+      base:
+        INFOPLIST_FILE: MarathonTraining/Resources/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.MarathonTraining
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+    info:
+      path: MarathonTraining/Resources/Info.plist
+      properties:
+        UILaunchScreen: {}
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        NSHealthShareUsageDescription: トレーニング記録と睡眠データを表示するために、ヘルスケアデータへのアクセスが必要です。
+    entitlements:
+      path: MarathonTraining/MarathonTraining.entitlements
+      properties:
+        com.apple.developer.healthkit: true
+        com.apple.developer.healthkit.access: []
+    dependencies: []
+    attributes:
+      SystemCapabilities:
+        com.apple.HealthKit:
+          enabled: true


### PR DESCRIPTION
## Summary
- Create Xcode project using xcodegen with SwiftUI and SwiftData
- Set iOS 17.0 minimum deployment target
- Add HealthKit capability and entitlements
- Add Info.plist with Japanese HealthKit usage description
- Create Clean Architecture directory structure (Domain, Data, Presentation layers)
- Add placeholder views for all screens (Home, WeeklyMenu, Records, Goals, Settings)

## Test plan
- [ ] Open project in Xcode and verify it builds successfully
- [ ] Verify HealthKit capability is enabled in Signing & Capabilities
- [ ] Verify iOS 17.0 minimum deployment target is set
- [ ] Verify directory structure matches implementation plan

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)