### PR TITLE
feat: Implement tab navigation with 5 tabs

### DIFF
--- a/MarathonTraining.xcodeproj/project.pbxproj
+++ b/MarathonTraining.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02AB5B9810FDE57D9B91C83B /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68601CF3E6827AFAB9E783C /* Tab.swift */; };
 		1F329660C154E2196370D62F /* SleepRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171562AE2F6152870FD521A4 /* SleepRecord.swift */; };
 		3DB311A0352E874807F280CA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6B615920679A5B6425AAFA /* SettingsView.swift */; };
 		48E5757A14DA59F1CC8E4E95 /* RecordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */; };
@@ -40,6 +41,7 @@
 		86EC631FD4930C1584D894B9 /* MarathonTraining.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MarathonTraining.entitlements; sourceTree = "<group>"; };
 		8C96D31363F79F305E2F5541 /* TrainingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingType.swift; sourceTree = "<group>"; };
 		953436DD6951BDD71CAC756E /* WeeklyMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyMenuView.swift; sourceTree = "<group>"; };
+		A68601CF3E6827AFAB9E783C /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		AA174E98F44AB02D9C7696E1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		BE149F2CC235729C2894B6D9 /* WeeklyGoalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyGoalModel.swift; sourceTree = "<group>"; };
 		D433E722CA64B2DF5ECD787E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -200,11 +202,12 @@
 			isa = PBXGroup;
 			children = (
 				AA174E98F44AB02D9C7696E1 /* ContentView.swift */,
+				A68601CF3E6827AFAB9E783C /* Tab.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
 		};
-		"TEMP_596C89F8-1EBF-4A12-A467-FAEC6FE388DE" /* Shared */ = {
+		"TEMP_8C0C05A4-AECB-40FE-9E69-149FAFE6501D" /* Shared */ = {
 			isa = PBXGroup;
 			children = (
 			);
@@ -297,6 +300,7 @@
 				A7EE6972B24E14313836E96D /* RunningWorkout.swift in Sources */,
 				3DB311A0352E874807F280CA /* SettingsView.swift in Sources */,
 				1F329660C154E2196370D62F /* SleepRecord.swift in Sources */,
+				02AB5B9810FDE57D9B91C83B /* Tab.swift in Sources */,
 				B133C2D3F032C11AB1069442 /* TrainingMenuModel.swift in Sources */,
 				C4329A4FCC9FE558B8C7466A /* TrainingType.swift in Sources */,
 				8FD4220BB7B9437E7E6475B2 /* WeeklyGoalModel.swift in Sources */,

--- a/MarathonTraining/App/ContentView.swift
+++ b/MarathonTraining/App/ContentView.swift
@@ -1,10 +1,37 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var selectedTab: Tab = .home
+
     var body: some View {
-        // Tab navigation will be implemented in Issue #10
-        Text("Marathon Training App")
-            .font(.title)
+        TabView(selection: $selectedTab) {
+            ForEach(Tab.allCases) { tab in
+                NavigationStack {
+                    tabContent(for: tab)
+                        .navigationTitle(tab.title)
+                }
+                .tabItem {
+                    Label(tab.title, systemImage: tab.icon)
+                }
+                .tag(tab)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func tabContent(for tab: Tab) -> some View {
+        switch tab {
+        case .home:
+            HomeView()
+        case .weeklyMenu:
+            WeeklyMenuView()
+        case .records:
+            RecordsView()
+        case .goals:
+            GoalsView()
+        case .settings:
+            SettingsView()
+        }
     }
 }
 

--- a/MarathonTraining/App/Tab.swift
+++ b/MarathonTraining/App/Tab.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Tab enum for app navigation
+enum Tab: Int, CaseIterable, Identifiable {
+    case home
+    case weeklyMenu
+    case records
+    case goals
+    case settings
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .home: return "ホーム"
+        case .weeklyMenu: return "メニュー"
+        case .records: return "記録"
+        case .goals: return "目標"
+        case .settings: return "設定"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .home: return "house.fill"
+        case .weeklyMenu: return "calendar"
+        case .records: return "chart.line.uptrend.xyaxis"
+        case .goals: return "flag.fill"
+        case .settings: return "gearshape.fill"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Tab enum with Japanese titles and SF Symbol icons
- Implement ContentView with TabView for main navigation
- Add NavigationStack for each tab
- Connect all 5 placeholder views (Home, WeeklyMenu, Records, Goals, Settings)

## Test plan
- [ ] Verify all 5 tabs are displayed correctly
- [ ] Verify tab icons show correctly
- [ ] Verify tab switching works properly
- [ ] Verify navigation titles display in Japanese

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)