### PR TITLE
feat: Implement home screen with countdown, weekly summary, and today menu

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,33 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(codex exec:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh pr merge:*)",
+      "Bash(gh issue close:*)",
+      "Bash(git checkout:*)",
+      "Bash(git pull:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git fetch:*)",
+      "Bash(git merge:*)",
+      "Bash(git branch:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr view:*)",
+      "Bash(xcodegen generate:*)",
+      "Bash(xcodebuild:*)",
+      "Bash(cat:*)",
+      "Bash(jq:*)",
+      "Bash(ls:*)",
+      "Bash(mkdir:*)",
+      "Bash(which:*)",
+      "Bash(brew install:*)"
+    ]
+  }
+}

--- a/MarathonTraining.xcodeproj/project.pbxproj
+++ b/MarathonTraining.xcodeproj/project.pbxproj
@@ -11,8 +11,12 @@
 		1F329660C154E2196370D62F /* SleepRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171562AE2F6152870FD521A4 /* SleepRecord.swift */; };
 		3DB311A0352E874807F280CA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6B615920679A5B6425AAFA /* SettingsView.swift */; };
 		48E5757A14DA59F1CC8E4E95 /* RecordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */; };
+		5987DF2D06FC24CCA287A431 /* TodayMenuCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8018D3B1B2E6494189418307 /* TodayMenuCard.swift */; };
 		5DE1FB967AB7507E5415A297 /* WeeklyMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953436DD6951BDD71CAC756E /* WeeklyMenuView.swift */; };
+		5EAF9C915224A821BDD60E41 /* WeeklySummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B550B305F6909BEBC11126 /* WeeklySummaryCard.swift */; };
+		7E91C6BF27836DFCD2199B73 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5018C41BB6D04354866DA7F /* HomeViewModel.swift */; };
 		86DFF99EC3386ECE483DAD6B /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7233A3B17BACE09E4F6B2D06 /* HomeView.swift */; };
+		8860297FB625FE4B96971FEE /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E68531B5DC6DEDA0584A1CC /* EmptyStateView.swift */; };
 		8FD4220BB7B9437E7E6475B2 /* WeeklyGoalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE149F2CC235729C2894B6D9 /* WeeklyGoalModel.swift */; };
 		9596D36AC457ECD9BE4FD2F5 /* RaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699AB2DA19ED9D53CA7DCF57 /* RaceModel.swift */; };
 		A056B5CFE7FD070D67A41C14 /* GoalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C35D2135867741362E3AE23 /* GoalType.swift */; };
@@ -24,6 +28,7 @@
 		E5F7195D34A29FFC2E893841 /* LongTermGoalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC0CFB5CFE231C528687E2F /* LongTermGoalModel.swift */; };
 		E9F02FA4336A69B219B9BE5E /* MarathonTrainingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60E1BFDF85EC77EAD3C6E91D /* MarathonTrainingApp.swift */; };
 		F3E16B53FAB717B0E0C99EE0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA174E98F44AB02D9C7696E1 /* ContentView.swift */; };
+		FA52EBCFC777E1A7D89DE730 /* CountdownCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88CF801CE7ACCDEE315A8708 /* CountdownCard.swift */; };
 		FCBF1DF16101468D84121079 /* HealthKitService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DA138DAED0EEB89EF1ECC52 /* HealthKitService.swift */; };
 /* End PBXBuildFile section */
 
@@ -35,14 +40,19 @@
 		3FBAFFDFA992C9C292C673C7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordsView.swift; sourceTree = "<group>"; };
 		60E1BFDF85EC77EAD3C6E91D /* MarathonTrainingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarathonTrainingApp.swift; sourceTree = "<group>"; };
+		63B550B305F6909BEBC11126 /* WeeklySummaryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklySummaryCard.swift; sourceTree = "<group>"; };
 		699AB2DA19ED9D53CA7DCF57 /* RaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceModel.swift; sourceTree = "<group>"; };
 		7233A3B17BACE09E4F6B2D06 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
+		8018D3B1B2E6494189418307 /* TodayMenuCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayMenuCard.swift; sourceTree = "<group>"; };
 		862EA7FAA86C60FDDA949048 /* TrainingMenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingMenuModel.swift; sourceTree = "<group>"; };
 		86EC631FD4930C1584D894B9 /* MarathonTraining.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MarathonTraining.entitlements; sourceTree = "<group>"; };
+		88CF801CE7ACCDEE315A8708 /* CountdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownCard.swift; sourceTree = "<group>"; };
 		8C96D31363F79F305E2F5541 /* TrainingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingType.swift; sourceTree = "<group>"; };
 		953436DD6951BDD71CAC756E /* WeeklyMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyMenuView.swift; sourceTree = "<group>"; };
+		9E68531B5DC6DEDA0584A1CC /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		A68601CF3E6827AFAB9E783C /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		AA174E98F44AB02D9C7696E1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		B5018C41BB6D04354866DA7F /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		BE149F2CC235729C2894B6D9 /* WeeklyGoalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyGoalModel.swift; sourceTree = "<group>"; };
 		D433E722CA64B2DF5ECD787E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DAC0CFB5CFE231C528687E2F /* LongTermGoalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongTermGoalModel.swift; sourceTree = "<group>"; };
@@ -59,6 +69,7 @@
 				757886FF777B674F109B31F0 /* Home */,
 				64757CBF1002F200C9690665 /* Records */,
 				D3A648F76330DAEF6E324CF8 /* Settings */,
+				1A2ED095A794FE176FD36955 /* Shared */,
 				590DD3DD9DFC98381AC510BC /* WeeklyMenu */,
 			);
 			path = Presentation;
@@ -75,6 +86,14 @@
 				BE149F2CC235729C2894B6D9 /* WeeklyGoalModel.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		1A2ED095A794FE176FD36955 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				B245AB20592F0A33B9C6E70B /* Components */,
+			);
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		25B6CCF6EB6F39567667AF8D = {
@@ -101,6 +120,16 @@
 				6B8C3DED727F0EE48125900E /* Services */,
 			);
 			path = Data;
+			sourceTree = "<group>";
+		};
+		4164F74EA69F0515FC3A1CFF /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				88CF801CE7ACCDEE315A8708 /* CountdownCard.swift */,
+				8018D3B1B2E6494189418307 /* TodayMenuCard.swift */,
+				63B550B305F6909BEBC11126 /* WeeklySummaryCard.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		5083631634AC5B436B0ABF49 /* HealthKit */ = {
@@ -139,6 +168,8 @@
 			isa = PBXGroup;
 			children = (
 				7233A3B17BACE09E4F6B2D06 /* HomeView.swift */,
+				B5018C41BB6D04354866DA7F /* HomeViewModel.swift */,
+				4164F74EA69F0515FC3A1CFF /* Components */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -157,6 +188,14 @@
 				2ED2127CD14BDECDA2BE61A0 /* Entities */,
 			);
 			path = Domain;
+			sourceTree = "<group>";
+		};
+		B245AB20592F0A33B9C6E70B /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				9E68531B5DC6DEDA0584A1CC /* EmptyStateView.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		B5A93E0A4DB18478FAF556E8 /* MarathonTraining */ = {
@@ -205,13 +244,6 @@
 				A68601CF3E6827AFAB9E783C /* Tab.swift */,
 			);
 			path = App;
-			sourceTree = "<group>";
-		};
-		"TEMP_8C0C05A4-AECB-40FE-9E69-149FAFE6501D" /* Shared */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Shared;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -289,10 +321,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				F3E16B53FAB717B0E0C99EE0 /* ContentView.swift in Sources */,
+				FA52EBCFC777E1A7D89DE730 /* CountdownCard.swift in Sources */,
+				8860297FB625FE4B96971FEE /* EmptyStateView.swift in Sources */,
 				A056B5CFE7FD070D67A41C14 /* GoalType.swift in Sources */,
 				E01EB93515BC732201678B26 /* GoalsView.swift in Sources */,
 				FCBF1DF16101468D84121079 /* HealthKitService.swift in Sources */,
 				86DFF99EC3386ECE483DAD6B /* HomeView.swift in Sources */,
+				7E91C6BF27836DFCD2199B73 /* HomeViewModel.swift in Sources */,
 				E5F7195D34A29FFC2E893841 /* LongTermGoalModel.swift in Sources */,
 				E9F02FA4336A69B219B9BE5E /* MarathonTrainingApp.swift in Sources */,
 				9596D36AC457ECD9BE4FD2F5 /* RaceModel.swift in Sources */,
@@ -301,10 +336,12 @@
 				3DB311A0352E874807F280CA /* SettingsView.swift in Sources */,
 				1F329660C154E2196370D62F /* SleepRecord.swift in Sources */,
 				02AB5B9810FDE57D9B91C83B /* Tab.swift in Sources */,
+				5987DF2D06FC24CCA287A431 /* TodayMenuCard.swift in Sources */,
 				B133C2D3F032C11AB1069442 /* TrainingMenuModel.swift in Sources */,
 				C4329A4FCC9FE558B8C7466A /* TrainingType.swift in Sources */,
 				8FD4220BB7B9437E7E6475B2 /* WeeklyGoalModel.swift in Sources */,
 				5DE1FB967AB7507E5415A297 /* WeeklyMenuView.swift in Sources */,
+				5EAF9C915224A821BDD60E41 /* WeeklySummaryCard.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MarathonTraining/Presentation/Home/Components/CountdownCard.swift
+++ b/MarathonTraining/Presentation/Home/Components/CountdownCard.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Card showing countdown to next race
+struct CountdownCard: View {
+    let race: RaceModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "flag.checkered")
+                    .foregroundStyle(.orange)
+                Text("次回大会")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(race.name)
+                    .font(.title3)
+                    .fontWeight(.semibold)
+
+                Text(race.date.formatted(date: .long, time: .omitted))
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack {
+                Spacer()
+                VStack {
+                    Text("あと")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("\(race.daysRemaining)")
+                        .font(.system(size: 48, weight: .bold, design: .rounded))
+                        .foregroundStyle(.orange)
+                    Text("日")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+
+            if let targetTime = race.formattedTargetTime {
+                HStack {
+                    Text("目標タイム")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(targetTime)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                }
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+}

--- a/MarathonTraining/Presentation/Home/Components/TodayMenuCard.swift
+++ b/MarathonTraining/Presentation/Home/Components/TodayMenuCard.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// Card showing today's training menu
+struct TodayMenuCard: View {
+    let menu: TrainingMenuModel?
+    let onComplete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "figure.run")
+                    .foregroundStyle(.green)
+                Text("本日のメニュー")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            if let menu = menu {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Image(systemName: menu.type.icon)
+                            .font(.title2)
+                            .foregroundStyle(.green)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(menu.type.displayName)
+                                .font(.headline)
+
+                            if let distance = menu.targetDistance {
+                                Text(String(format: "%.1f km", distance))
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            if let pace = menu.formattedTargetPace {
+                                Text("ペース: \(pace)")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+
+                        Spacer()
+
+                        if menu.isCompleted {
+                            Image(systemName: "checkmark.circle.fill")
+                                .font(.title)
+                                .foregroundStyle(.green)
+                        }
+                    }
+
+                    if let description = menu.menuDescription {
+                        Text(description)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if !menu.isCompleted {
+                        Button(action: onComplete) {
+                            Text("完了する")
+                                .font(.headline)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                                .background(Color.green)
+                                .foregroundStyle(.white)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        }
+                        .padding(.top, 4)
+                    }
+                }
+            } else {
+                VStack(spacing: 8) {
+                    Image(systemName: "calendar.badge.exclamationmark")
+                        .font(.largeTitle)
+                        .foregroundStyle(.secondary)
+
+                    Text("本日のメニューはありません")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Text("週間メニューで設定してください")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical)
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+}

--- a/MarathonTraining/Presentation/Home/Components/WeeklySummaryCard.swift
+++ b/MarathonTraining/Presentation/Home/Components/WeeklySummaryCard.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// Card showing weekly training progress
+struct WeeklySummaryCard: View {
+    let currentDistance: Double
+    let goalDistance: Double
+    let achievementRate: Double
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "chart.bar.fill")
+                    .foregroundStyle(.blue)
+                Text("今週のサマリー")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("走行距離")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(String(format: "%.1f km / %.0f km", currentDistance, goalDistance))
+                        .font(.headline)
+                }
+
+                GeometryReader { geometry in
+                    ZStack(alignment: .leading) {
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color(.systemGray5))
+                            .frame(height: 12)
+
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(
+                                LinearGradient(
+                                    colors: [.blue, .cyan],
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
+                            )
+                            .frame(width: geometry.size.width * achievementRate, height: 12)
+                    }
+                }
+                .frame(height: 12)
+
+                HStack {
+                    Spacer()
+                    Text(String(format: "%.0f%%", achievementRate * 100))
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundStyle(achievementRate >= 1.0 ? .green : .secondary)
+                }
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .shadow(color: .black.opacity(0.1), radius: 8, x: 0, y: 2)
+    }
+}

--- a/MarathonTraining/Presentation/Home/HomeView.swift
+++ b/MarathonTraining/Presentation/Home/HomeView.swift
@@ -1,11 +1,73 @@
 import SwiftUI
+import SwiftData
 
 struct HomeView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var viewModel = HomeViewModel()
+    @State private var healthKitService = HealthKitService()
+
     var body: some View {
-        Text("Home")
+        ScrollView {
+            VStack(spacing: 16) {
+                if viewModel.isLoading {
+                    ProgressView()
+                        .padding(.top, 40)
+                } else if let race = viewModel.upcomingRace {
+                    // Countdown Card
+                    CountdownCard(race: race)
+                        .padding(.horizontal)
+
+                    // Weekly Summary Card
+                    WeeklySummaryCard(
+                        currentDistance: viewModel.thisWeekDistance,
+                        goalDistance: viewModel.thisWeekGoalDistance,
+                        achievementRate: viewModel.thisWeekAchievementRate
+                    )
+                    .padding(.horizontal)
+
+                    // Today's Menu Card
+                    TodayMenuCard(
+                        menu: viewModel.todayMenu,
+                        onComplete: {
+                            Task {
+                                await viewModel.markTodayMenuAsCompleted()
+                            }
+                        }
+                    )
+                    .padding(.horizontal)
+                } else {
+                    // Empty state when no race registered
+                    EmptyStateView(
+                        icon: "flag",
+                        title: "大会が登録されていません",
+                        message: "目標の大会を登録して\nトレーニングを始めましょう",
+                        actionTitle: "目標タブへ",
+                        action: nil
+                    )
+                    .padding(.top, 40)
+                }
+
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .padding()
+                }
+            }
+            .padding(.vertical)
+        }
+        .background(Color(.systemGroupedBackground))
+        .refreshable {
+            await viewModel.loadData()
+        }
+        .task {
+            viewModel.configure(modelContext: modelContext, healthKitService: healthKitService)
+            await viewModel.loadData()
+        }
     }
 }
 
 #Preview {
     HomeView()
+        .modelContainer(for: [RaceModel.self, TrainingMenuModel.self, WeeklyGoalModel.self])
 }

--- a/MarathonTraining/Presentation/Home/HomeViewModel.swift
+++ b/MarathonTraining/Presentation/Home/HomeViewModel.swift
@@ -1,0 +1,151 @@
+import Foundation
+import SwiftData
+import Observation
+
+/// ViewModel for the Home screen
+@Observable
+final class HomeViewModel {
+    private var modelContext: ModelContext?
+    private var healthKitService: HealthKitService?
+
+    var upcomingRace: RaceModel?
+    var thisWeekDistance: Double = 0
+    var thisWeekGoalDistance: Double = 0
+    var thisWeekAchievementRate: Double = 0
+    var todayMenu: TrainingMenuModel?
+    var recentWorkouts: [RunningWorkout] = []
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    func configure(modelContext: ModelContext, healthKitService: HealthKitService) {
+        self.modelContext = modelContext
+        self.healthKitService = healthKitService
+    }
+
+    @MainActor
+    func loadData() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            await loadUpcomingRace()
+            await loadWeeklyProgress()
+            await loadTodayMenu()
+            try await loadRecentWorkouts()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    @MainActor
+    private func loadUpcomingRace() async {
+        guard let modelContext = modelContext else { return }
+
+        let now = Date()
+        let descriptor = FetchDescriptor<RaceModel>(
+            predicate: #Predicate { race in
+                race.date > now
+            },
+            sortBy: [SortDescriptor(\.date, order: .forward)]
+        )
+
+        do {
+            let races = try modelContext.fetch(descriptor)
+            upcomingRace = races.first
+        } catch {
+            print("Failed to fetch races: \(error)")
+        }
+    }
+
+    @MainActor
+    private func loadWeeklyProgress() async {
+        guard let modelContext = modelContext else { return }
+
+        let calendar = Calendar.current
+        let now = Date()
+        guard let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: now)) else { return }
+        guard let weekEnd = calendar.date(byAdding: .day, value: 7, to: weekStart) else { return }
+
+        // Fetch weekly goal
+        let goalDescriptor = FetchDescriptor<WeeklyGoalModel>(
+            predicate: #Predicate { goal in
+                goal.weekStartDate >= weekStart && goal.weekStartDate < weekEnd
+            }
+        )
+
+        do {
+            let goals = try modelContext.fetch(goalDescriptor)
+            if let goal = goals.first {
+                thisWeekGoalDistance = goal.targetDistance
+            } else {
+                thisWeekGoalDistance = 30  // Default 30km
+            }
+        } catch {
+            thisWeekGoalDistance = 30
+        }
+
+        // Fetch completed training menus for this week
+        let menuDescriptor = FetchDescriptor<TrainingMenuModel>(
+            predicate: #Predicate { menu in
+                menu.date >= weekStart && menu.date < weekEnd && menu.isCompleted
+            }
+        )
+
+        do {
+            let menus = try modelContext.fetch(menuDescriptor)
+            thisWeekDistance = menus.compactMap { $0.targetDistance }.reduce(0, +)
+            thisWeekAchievementRate = thisWeekGoalDistance > 0 ? min(thisWeekDistance / thisWeekGoalDistance, 1.0) : 0
+        } catch {
+            thisWeekDistance = 0
+            thisWeekAchievementRate = 0
+        }
+    }
+
+    @MainActor
+    private func loadTodayMenu() async {
+        guard let modelContext = modelContext else { return }
+
+        let calendar = Calendar.current
+        let todayStart = calendar.startOfDay(for: Date())
+        guard let todayEnd = calendar.date(byAdding: .day, value: 1, to: todayStart) else { return }
+
+        let descriptor = FetchDescriptor<TrainingMenuModel>(
+            predicate: #Predicate { menu in
+                menu.date >= todayStart && menu.date < todayEnd
+            }
+        )
+
+        do {
+            let menus = try modelContext.fetch(descriptor)
+            todayMenu = menus.first
+        } catch {
+            print("Failed to fetch today's menu: \(error)")
+        }
+    }
+
+    private func loadRecentWorkouts() async throws {
+        guard let healthKitService = healthKitService else { return }
+
+        let calendar = Calendar.current
+        let now = Date()
+        guard let weekAgo = calendar.date(byAdding: .day, value: -7, to: now) else { return }
+
+        recentWorkouts = try await healthKitService.fetchRunningWorkouts(from: weekAgo, to: now)
+    }
+
+    @MainActor
+    func markTodayMenuAsCompleted() async {
+        guard let todayMenu = todayMenu else { return }
+
+        todayMenu.markAsCompleted()
+
+        do {
+            try modelContext?.save()
+            await loadWeeklyProgress()
+        } catch {
+            print("Failed to save: \(error)")
+        }
+    }
+}

--- a/MarathonTraining/Presentation/Shared/Components/EmptyStateView.swift
+++ b/MarathonTraining/Presentation/Shared/Components/EmptyStateView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Reusable empty state view
+struct EmptyStateView: View {
+    let icon: String
+    let title: String
+    let message: String
+    let actionTitle: String?
+    let action: (() -> Void)?
+
+    init(
+        icon: String,
+        title: String,
+        message: String,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) {
+        self.icon = icon
+        self.title = title
+        self.message = message
+        self.actionTitle = actionTitle
+        self.action = action
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.system(size: 64))
+                .foregroundStyle(.secondary)
+
+            Text(title)
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text(message)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let actionTitle = actionTitle, let action = action {
+                Button(action: action) {
+                    Text(actionTitle)
+                        .font(.headline)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 12)
+                        .background(Color.accentColor)
+                        .foregroundStyle(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                .padding(.top, 8)
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    EmptyStateView(
+        icon: "flag",
+        title: "大会が登録されていません",
+        message: "目標の大会を登録して\nトレーニングを始めましょう",
+        actionTitle: "大会を追加",
+        action: {}
+    )
+}


### PR DESCRIPTION
## Summary
- Add HomeViewModel with @Observable for state management
- Implement CountdownCard showing next race name, date, and days remaining
- Implement WeeklySummaryCard with progress bar showing weekly distance vs goal
- Implement TodayMenuCard showing today's training with completion button
- Add EmptyStateView shared component for no-data states
- Integrate with SwiftData for data persistence
- Integrate with HealthKitService for recent workouts
- Add pull-to-refresh support

## Test plan
- [ ] Verify home screen displays correctly with empty data
- [ ] Verify countdown card shows correct days remaining
- [ ] Verify weekly summary progress bar reflects actual progress
- [ ] Verify today menu completion updates weekly summary
- [ ] Verify pull-to-refresh reloads data

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)