### PR TITLE
feat: Implement weekly menu screen with calendar and templates

### DIFF
--- a/MarathonTraining.xcodeproj/project.pbxproj
+++ b/MarathonTraining.xcodeproj/project.pbxproj
@@ -8,7 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		02AB5B9810FDE57D9B91C83B /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68601CF3E6827AFAB9E783C /* Tab.swift */; };
+		1D7DD784DA0C60556D04B487 /* MenuTemplateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB670E43771D3208B7FD2DF /* MenuTemplateSheet.swift */; };
 		1F329660C154E2196370D62F /* SleepRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171562AE2F6152870FD521A4 /* SleepRecord.swift */; };
+		21257451B0CBF18D80073ADA /* WeeklyMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCAA8182C3D3D66B7F10FA4 /* WeeklyMenuViewModel.swift */; };
+		30A010D6F1624F2A29D111D3 /* WeekCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BC5F341DEEAF38FD217CD3 /* WeekCalendarView.swift */; };
 		3DB311A0352E874807F280CA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6B615920679A5B6425AAFA /* SettingsView.swift */; };
 		48E5757A14DA59F1CC8E4E95 /* RecordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */; };
 		5987DF2D06FC24CCA287A431 /* TodayMenuCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8018D3B1B2E6494189418307 /* TodayMenuCard.swift */; };
@@ -23,6 +26,7 @@
 		A7EE6972B24E14313836E96D /* RunningWorkout.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB96FA62E2AB87E4012C6E74 /* RunningWorkout.swift */; };
 		B133C2D3F032C11AB1069442 /* TrainingMenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862EA7FAA86C60FDDA949048 /* TrainingMenuModel.swift */; };
 		BC3A8373A1CE6681F0FF20F2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3FBAFFDFA992C9C292C673C7 /* Assets.xcassets */; };
+		C4121A826AB3F1954AACC2B5 /* DayMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76891E8C7302E20BFD3F4E5 /* DayMenuCell.swift */; };
 		C4329A4FCC9FE558B8C7466A /* TrainingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C96D31363F79F305E2F5541 /* TrainingType.swift */; };
 		E01EB93515BC732201678B26 /* GoalsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F56431ECF8DF3CECF3383E87 /* GoalsView.swift */; };
 		E5F7195D34A29FFC2E893841 /* LongTermGoalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC0CFB5CFE231C528687E2F /* LongTermGoalModel.swift */; };
@@ -36,8 +40,10 @@
 		171562AE2F6152870FD521A4 /* SleepRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepRecord.swift; sourceTree = "<group>"; };
 		1AD7264A823F71D85F424F2C /* MarathonTraining.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MarathonTraining.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C35D2135867741362E3AE23 /* GoalType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalType.swift; sourceTree = "<group>"; };
+		34BC5F341DEEAF38FD217CD3 /* WeekCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekCalendarView.swift; sourceTree = "<group>"; };
 		3DA138DAED0EEB89EF1ECC52 /* HealthKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitService.swift; sourceTree = "<group>"; };
 		3FBAFFDFA992C9C292C673C7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4FCAA8182C3D3D66B7F10FA4 /* WeeklyMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyMenuViewModel.swift; sourceTree = "<group>"; };
 		5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordsView.swift; sourceTree = "<group>"; };
 		60E1BFDF85EC77EAD3C6E91D /* MarathonTrainingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarathonTrainingApp.swift; sourceTree = "<group>"; };
 		63B550B305F6909BEBC11126 /* WeeklySummaryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklySummaryCard.swift; sourceTree = "<group>"; };
@@ -53,6 +59,8 @@
 		A68601CF3E6827AFAB9E783C /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
 		AA174E98F44AB02D9C7696E1 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		B5018C41BB6D04354866DA7F /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		B76891E8C7302E20BFD3F4E5 /* DayMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayMenuCell.swift; sourceTree = "<group>"; };
+		BBB670E43771D3208B7FD2DF /* MenuTemplateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTemplateSheet.swift; sourceTree = "<group>"; };
 		BE149F2CC235729C2894B6D9 /* WeeklyGoalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyGoalModel.swift; sourceTree = "<group>"; };
 		D433E722CA64B2DF5ECD787E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DAC0CFB5CFE231C528687E2F /* LongTermGoalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongTermGoalModel.swift; sourceTree = "<group>"; };
@@ -104,6 +112,16 @@
 			);
 			sourceTree = "<group>";
 		};
+		25F45AFF6B4ED77319EADB01 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				B76891E8C7302E20BFD3F4E5 /* DayMenuCell.swift */,
+				BBB670E43771D3208B7FD2DF /* MenuTemplateSheet.swift */,
+				34BC5F341DEEAF38FD217CD3 /* WeekCalendarView.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
 		2ED2127CD14BDECDA2BE61A0 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +162,8 @@
 			isa = PBXGroup;
 			children = (
 				953436DD6951BDD71CAC756E /* WeeklyMenuView.swift */,
+				4FCAA8182C3D3D66B7F10FA4 /* WeeklyMenuViewModel.swift */,
+				25F45AFF6B4ED77319EADB01 /* Components */,
 			);
 			path = WeeklyMenu;
 			sourceTree = "<group>";
@@ -322,6 +342,7 @@
 			files = (
 				F3E16B53FAB717B0E0C99EE0 /* ContentView.swift in Sources */,
 				FA52EBCFC777E1A7D89DE730 /* CountdownCard.swift in Sources */,
+				C4121A826AB3F1954AACC2B5 /* DayMenuCell.swift in Sources */,
 				8860297FB625FE4B96971FEE /* EmptyStateView.swift in Sources */,
 				A056B5CFE7FD070D67A41C14 /* GoalType.swift in Sources */,
 				E01EB93515BC732201678B26 /* GoalsView.swift in Sources */,
@@ -330,6 +351,7 @@
 				7E91C6BF27836DFCD2199B73 /* HomeViewModel.swift in Sources */,
 				E5F7195D34A29FFC2E893841 /* LongTermGoalModel.swift in Sources */,
 				E9F02FA4336A69B219B9BE5E /* MarathonTrainingApp.swift in Sources */,
+				1D7DD784DA0C60556D04B487 /* MenuTemplateSheet.swift in Sources */,
 				9596D36AC457ECD9BE4FD2F5 /* RaceModel.swift in Sources */,
 				48E5757A14DA59F1CC8E4E95 /* RecordsView.swift in Sources */,
 				A7EE6972B24E14313836E96D /* RunningWorkout.swift in Sources */,
@@ -339,8 +361,10 @@
 				5987DF2D06FC24CCA287A431 /* TodayMenuCard.swift in Sources */,
 				B133C2D3F032C11AB1069442 /* TrainingMenuModel.swift in Sources */,
 				C4329A4FCC9FE558B8C7466A /* TrainingType.swift in Sources */,
+				30A010D6F1624F2A29D111D3 /* WeekCalendarView.swift in Sources */,
 				8FD4220BB7B9437E7E6475B2 /* WeeklyGoalModel.swift in Sources */,
 				5DE1FB967AB7507E5415A297 /* WeeklyMenuView.swift in Sources */,
+				21257451B0CBF18D80073ADA /* WeeklyMenuViewModel.swift in Sources */,
 				5EAF9C915224A821BDD60E41 /* WeeklySummaryCard.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/MarathonTraining/Presentation/WeeklyMenu/Components/DayMenuCell.swift
+++ b/MarathonTraining/Presentation/WeeklyMenu/Components/DayMenuCell.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// Cell displaying a single day's training menu
+struct DayMenuCell: View {
+    let date: Date
+    let menu: TrainingMenuModel?
+    let onToggleCompletion: () -> Void
+
+    private let calendar = Calendar.current
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "M/d (E)"
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(dateFormatter.string(from: date))
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                if calendar.isDateInToday(date) {
+                    Text("今日")
+                        .font(.caption2)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.accentColor)
+                        .foregroundStyle(.white)
+                        .clipShape(Capsule())
+                }
+
+                Spacer()
+            }
+
+            if let menu = menu {
+                HStack {
+                    Image(systemName: menu.type.icon)
+                        .font(.title2)
+                        .foregroundStyle(menu.type == .rest ? Color.secondary : Color.orange)
+                        .frame(width: 32)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(menu.type.displayName)
+                            .font(.headline)
+
+                        if menu.type != .rest {
+                            HStack(spacing: 8) {
+                                if let distance = menu.targetDistance {
+                                    Text(String(format: "%.0fkm", distance))
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                if let pace = menu.formattedTargetPace {
+                                    Text(pace)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer()
+
+                    Button(action: onToggleCompletion) {
+                        Image(systemName: menu.isCompleted ? "checkmark.circle.fill" : "circle")
+                            .font(.title2)
+                            .foregroundStyle(menu.isCompleted ? .green : .secondary)
+                    }
+                    .disabled(menu.type == .rest)
+                }
+            } else {
+                HStack {
+                    Image(systemName: "calendar.badge.plus")
+                        .font(.title2)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 32)
+
+                    Text("メニュー未設定")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+                }
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/MarathonTraining/Presentation/WeeklyMenu/Components/MenuTemplateSheet.swift
+++ b/MarathonTraining/Presentation/WeeklyMenu/Components/MenuTemplateSheet.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Sheet for selecting training template
+struct MenuTemplateSheet: View {
+    let onSelectTemplate: (TrainingLevel) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(TrainingLevel.allCases, id: \.self) { level in
+                        Button {
+                            onSelectTemplate(level)
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(level.displayName)
+                                        .font(.headline)
+                                        .foregroundStyle(.primary)
+
+                                    Text("週\(level.trainingDays)日トレーニング")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                Spacer()
+
+                                Image(systemName: "chevron.right")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                } header: {
+                    Text("テンプレートを選択")
+                } footer: {
+                    Text("選択すると今週のメニューが上書きされます")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("週間メニュー設定")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    MenuTemplateSheet { level in
+        print("Selected: \(level)")
+    }
+}

--- a/MarathonTraining/Presentation/WeeklyMenu/Components/WeekCalendarView.swift
+++ b/MarathonTraining/Presentation/WeeklyMenu/Components/WeekCalendarView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// Week calendar header view
+struct WeekCalendarView: View {
+    let dates: [Date]
+    let menuForDate: (Date) -> TrainingMenuModel?
+    @Binding var selectedDate: Date?
+
+    private let calendar = Calendar.current
+    private let dayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "E"
+        return formatter
+    }()
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(dates, id: \.self) { date in
+                let menu = menuForDate(date)
+                let isSelected = selectedDate.map { calendar.isDate($0, inSameDayAs: date) } ?? false
+                let isToday = calendar.isDateInToday(date)
+
+                VStack(spacing: 4) {
+                    Text(dayFormatter.string(from: date))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+
+                    Text("\(calendar.component(.day, from: date))")
+                        .font(.subheadline)
+                        .fontWeight(isToday ? .bold : .regular)
+
+                    if let menu = menu {
+                        Image(systemName: menu.type.icon)
+                            .font(.caption)
+                            .foregroundStyle(menu.isCompleted ? .green : .orange)
+                    } else {
+                        Image(systemName: "minus")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(isSelected ? Color.accentColor.opacity(0.2) : Color.clear)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(isToday ? Color.accentColor : Color.clear, lineWidth: 2)
+                )
+                .onTapGesture {
+                    selectedDate = date
+                }
+            }
+        }
+        .padding(.horizontal)
+    }
+}

--- a/MarathonTraining/Presentation/WeeklyMenu/WeeklyMenuView.swift
+++ b/MarathonTraining/Presentation/WeeklyMenu/WeeklyMenuView.swift
@@ -1,11 +1,91 @@
 import SwiftUI
+import SwiftData
 
 struct WeeklyMenuView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var viewModel = WeeklyMenuViewModel()
+    @State private var selectedDate: Date?
+
     var body: some View {
-        Text("Weekly Menu")
+        VStack(spacing: 0) {
+            // Week navigation header
+            HStack {
+                Button(action: viewModel.previousWeek) {
+                    Image(systemName: "chevron.left")
+                        .font(.title3)
+                }
+
+                Spacer()
+
+                Text(viewModel.weekTitle)
+                    .font(.headline)
+
+                Spacer()
+
+                Button(action: viewModel.nextWeek) {
+                    Image(systemName: "chevron.right")
+                        .font(.title3)
+                }
+            }
+            .padding()
+
+            // Week calendar
+            WeekCalendarView(
+                dates: viewModel.weekDates(),
+                menuForDate: { viewModel.menu(for: $0) },
+                selectedDate: $selectedDate
+            )
+            .padding(.bottom)
+
+            Divider()
+
+            // Daily menu list
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    ForEach(viewModel.weekDates(), id: \.self) { date in
+                        DayMenuCell(
+                            date: date,
+                            menu: viewModel.menu(for: date),
+                            onToggleCompletion: {
+                                if let menu = viewModel.menu(for: date) {
+                                    Task {
+                                        await viewModel.toggleMenuCompletion(menu)
+                                    }
+                                }
+                            }
+                        )
+                    }
+                }
+                .padding()
+            }
+            .background(Color(.systemGroupedBackground))
+        }
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    viewModel.showingTemplateSheet = true
+                } label: {
+                    Image(systemName: "square.grid.2x2")
+                }
+            }
+        }
+        .sheet(isPresented: $viewModel.showingTemplateSheet) {
+            MenuTemplateSheet { level in
+                Task {
+                    await viewModel.applyTemplate(level)
+                }
+            }
+        }
+        .task {
+            viewModel.configure(modelContext: modelContext)
+            await viewModel.loadWeekData()
+        }
     }
 }
 
 #Preview {
-    WeeklyMenuView()
+    NavigationStack {
+        WeeklyMenuView()
+            .modelContainer(for: [TrainingMenuModel.self, WeeklyGoalModel.self])
+    }
 }

--- a/MarathonTraining/Presentation/WeeklyMenu/WeeklyMenuViewModel.swift
+++ b/MarathonTraining/Presentation/WeeklyMenu/WeeklyMenuViewModel.swift
@@ -1,0 +1,246 @@
+import Foundation
+import SwiftData
+import Observation
+
+/// Training level for menu templates
+enum TrainingLevel: String, CaseIterable {
+    case beginner
+    case intermediate
+    case advanced
+
+    var displayName: String {
+        switch self {
+        case .beginner: return "初心者（週30km）"
+        case .intermediate: return "中級者（週50km）"
+        case .advanced: return "上級者（週70km）"
+        }
+    }
+
+    var weeklyDistance: Double {
+        switch self {
+        case .beginner: return 30
+        case .intermediate: return 50
+        case .advanced: return 70
+        }
+    }
+
+    var trainingDays: Int {
+        switch self {
+        case .beginner: return 4
+        case .intermediate: return 5
+        case .advanced: return 6
+        }
+    }
+}
+
+/// ViewModel for Weekly Menu screen
+@Observable
+final class WeeklyMenuViewModel {
+    private var modelContext: ModelContext?
+
+    var currentWeekStart: Date = Date()
+    var weeklyMenus: [TrainingMenuModel] = []
+    var weeklyGoal: WeeklyGoalModel?
+    var isLoading: Bool = false
+    var showingTemplateSheet: Bool = false
+
+    init() {
+        // Set to Monday of current week
+        let calendar = Calendar.current
+        if let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date())) {
+            currentWeekStart = weekStart
+        }
+    }
+
+    func configure(modelContext: ModelContext) {
+        self.modelContext = modelContext
+    }
+
+    @MainActor
+    func loadWeekData() async {
+        guard let modelContext = modelContext else { return }
+
+        isLoading = true
+
+        let calendar = Calendar.current
+        let weekStart = currentWeekStart
+        guard let weekEnd = calendar.date(byAdding: .day, value: 7, to: weekStart) else { return }
+
+        // Fetch weekly menus
+        let menuDescriptor = FetchDescriptor<TrainingMenuModel>(
+            predicate: #Predicate { menu in
+                menu.date >= weekStart && menu.date < weekEnd
+            },
+            sortBy: [SortDescriptor(\.date, order: .forward)]
+        )
+
+        do {
+            weeklyMenus = try modelContext.fetch(menuDescriptor)
+        } catch {
+            print("Failed to fetch menus: \(error)")
+            weeklyMenus = []
+        }
+
+        // Fetch weekly goal
+        let goalDescriptor = FetchDescriptor<WeeklyGoalModel>(
+            predicate: #Predicate { goal in
+                goal.weekStartDate >= weekStart && goal.weekStartDate < weekEnd
+            }
+        )
+
+        do {
+            let goals = try modelContext.fetch(goalDescriptor)
+            weeklyGoal = goals.first
+        } catch {
+            print("Failed to fetch goal: \(error)")
+            weeklyGoal = nil
+        }
+
+        isLoading = false
+    }
+
+    func previousWeek() {
+        let calendar = Calendar.current
+        if let newStart = calendar.date(byAdding: .day, value: -7, to: currentWeekStart) {
+            currentWeekStart = newStart
+            Task {
+                await loadWeekData()
+            }
+        }
+    }
+
+    func nextWeek() {
+        let calendar = Calendar.current
+        if let newStart = calendar.date(byAdding: .day, value: 7, to: currentWeekStart) {
+            currentWeekStart = newStart
+            Task {
+                await loadWeekData()
+            }
+        }
+    }
+
+    @MainActor
+    func applyTemplate(_ level: TrainingLevel) async {
+        guard let modelContext = modelContext else { return }
+
+        let calendar = Calendar.current
+
+        // Delete existing menus for this week
+        for menu in weeklyMenus {
+            modelContext.delete(menu)
+        }
+
+        // Create or update weekly goal
+        if weeklyGoal == nil {
+            weeklyGoal = WeeklyGoalModel(
+                weekStartDate: currentWeekStart,
+                targetDistance: level.weeklyDistance,
+                targetTrainingDays: level.trainingDays
+            )
+            modelContext.insert(weeklyGoal!)
+        } else {
+            weeklyGoal?.targetDistance = level.weeklyDistance
+            weeklyGoal?.targetTrainingDays = level.trainingDays
+        }
+
+        // Create menus based on template
+        let template = getTemplate(for: level)
+        for (dayOffset, menuType) in template.enumerated() {
+            guard let menuDate = calendar.date(byAdding: .day, value: dayOffset, to: currentWeekStart) else { continue }
+
+            let menu = TrainingMenuModel(
+                date: menuDate,
+                type: menuType.type,
+                targetDistance: menuType.distance,
+                targetPace: menuType.pace
+            )
+            menu.weeklyGoal = weeklyGoal
+            modelContext.insert(menu)
+        }
+
+        do {
+            try modelContext.save()
+            await loadWeekData()
+        } catch {
+            print("Failed to save template: \(error)")
+        }
+
+        showingTemplateSheet = false
+    }
+
+    @MainActor
+    func toggleMenuCompletion(_ menu: TrainingMenuModel) async {
+        if menu.isCompleted {
+            menu.isCompleted = false
+            menu.completedAt = nil
+        } else {
+            menu.markAsCompleted()
+        }
+
+        do {
+            try modelContext?.save()
+        } catch {
+            print("Failed to save: \(error)")
+        }
+    }
+
+    private func getTemplate(for level: TrainingLevel) -> [(type: TrainingType, distance: Double?, pace: Double?)] {
+        switch level {
+        case .beginner:
+            return [
+                (type: .easy, distance: 5, pace: 6.5),
+                (type: .rest, distance: nil, pace: nil),
+                (type: .easy, distance: 5, pace: 6.5),
+                (type: .rest, distance: nil, pace: nil),
+                (type: .easy, distance: 3, pace: 7.0),
+                (type: .longRun, distance: 10, pace: 7.0),
+                (type: .rest, distance: nil, pace: nil),
+            ]
+        case .intermediate:
+            return [
+                (type: .easy, distance: 8, pace: 5.5),
+                (type: .tempo, distance: 6, pace: 5.0),
+                (type: .easy, distance: 8, pace: 5.5),
+                (type: .rest, distance: nil, pace: nil),
+                (type: .interval, distance: 6, pace: 4.5),
+                (type: .longRun, distance: 15, pace: 6.0),
+                (type: .recovery, distance: 5, pace: 6.5),
+            ]
+        case .advanced:
+            return [
+                (type: .easy, distance: 10, pace: 5.0),
+                (type: .tempo, distance: 10, pace: 4.5),
+                (type: .easy, distance: 10, pace: 5.0),
+                (type: .interval, distance: 8, pace: 4.0),
+                (type: .easy, distance: 8, pace: 5.0),
+                (type: .longRun, distance: 20, pace: 5.5),
+                (type: .recovery, distance: 6, pace: 6.0),
+            ]
+        }
+    }
+
+    func menu(for date: Date) -> TrainingMenuModel? {
+        let calendar = Calendar.current
+        return weeklyMenus.first { menu in
+            calendar.isDate(menu.date, inSameDayAs: date)
+        }
+    }
+
+    func weekDates() -> [Date] {
+        let calendar = Calendar.current
+        return (0..<7).compactMap { dayOffset in
+            calendar.date(byAdding: .day, value: dayOffset, to: currentWeekStart)
+        }
+    }
+
+    var weekTitle: String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "yyyy年M月"
+
+        let calendar = Calendar.current
+        let weekOfMonth = calendar.component(.weekOfMonth, from: currentWeekStart)
+
+        return "\(formatter.string(from: currentWeekStart)) 第\(weekOfMonth)週"
+    }
+}

--- a/MarathonTraining/Presentation/WeeklyMenu/WeeklyMenuViewModel.swift
+++ b/MarathonTraining/Presentation/WeeklyMenu/WeeklyMenuViewModel.swift
@@ -124,29 +124,48 @@ final class WeeklyMenuViewModel {
         guard let modelContext = modelContext else { return }
 
         let calendar = Calendar.current
+        let weekStart = currentWeekStart
+        guard let weekEnd = calendar.date(byAdding: .day, value: 7, to: weekStart) else { return }
+
+        // Fetch fresh data for the current week to avoid race conditions
+        let menuDescriptor = FetchDescriptor<TrainingMenuModel>(
+            predicate: #Predicate { menu in
+                menu.date >= weekStart && menu.date < weekEnd
+            }
+        )
+        let existingMenus = (try? modelContext.fetch(menuDescriptor)) ?? []
+
+        let goalDescriptor = FetchDescriptor<WeeklyGoalModel>(
+            predicate: #Predicate { goal in
+                goal.weekStartDate >= weekStart && goal.weekStartDate < weekEnd
+            }
+        )
+        let existingGoal = (try? modelContext.fetch(goalDescriptor))?.first
 
         // Delete existing menus for this week
-        for menu in weeklyMenus {
+        for menu in existingMenus {
             modelContext.delete(menu)
         }
 
         // Create or update weekly goal
-        if weeklyGoal == nil {
-            weeklyGoal = WeeklyGoalModel(
-                weekStartDate: currentWeekStart,
+        let goalToUse: WeeklyGoalModel
+        if let existingGoal = existingGoal {
+            existingGoal.targetDistance = level.weeklyDistance
+            existingGoal.targetTrainingDays = level.trainingDays
+            goalToUse = existingGoal
+        } else {
+            goalToUse = WeeklyGoalModel(
+                weekStartDate: weekStart,
                 targetDistance: level.weeklyDistance,
                 targetTrainingDays: level.trainingDays
             )
-            modelContext.insert(weeklyGoal!)
-        } else {
-            weeklyGoal?.targetDistance = level.weeklyDistance
-            weeklyGoal?.targetTrainingDays = level.trainingDays
+            modelContext.insert(goalToUse)
         }
 
         // Create menus based on template
         let template = getTemplate(for: level)
         for (dayOffset, menuType) in template.enumerated() {
-            guard let menuDate = calendar.date(byAdding: .day, value: dayOffset, to: currentWeekStart) else { continue }
+            guard let menuDate = calendar.date(byAdding: .day, value: dayOffset, to: weekStart) else { continue }
 
             let menu = TrainingMenuModel(
                 date: menuDate,
@@ -154,7 +173,7 @@ final class WeeklyMenuViewModel {
                 targetDistance: menuType.distance,
                 targetPace: menuType.pace
             )
-            menu.weeklyGoal = weeklyGoal
+            menu.weeklyGoal = goalToUse
             modelContext.insert(menu)
         }
 


### PR DESCRIPTION
## Summary
- Add WeeklyMenuViewModel with week navigation and template logic
- Implement WeekCalendarView showing 7-day overview with training icons
- Implement DayMenuCell with training type, distance, pace, and completion toggle
- Add MenuTemplateSheet with 3 training levels (beginner/intermediate/advanced)
- Add TrainingLevel enum with weekly distance and training day targets
- Implement menu completion tracking per day

## Test plan
- [ ] Verify week calendar displays correctly
- [ ] Verify week navigation (previous/next) works
- [ ] Verify template application creates correct menus
- [ ] Verify completion toggle updates menu status
- [ ] Verify Japanese day names display correctly

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)