### PR TITLE
feat: Implement records screen with running and sleep history

### DIFF
--- a/MarathonTraining.xcodeproj/project.pbxproj
+++ b/MarathonTraining.xcodeproj/project.pbxproj
@@ -8,10 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		02AB5B9810FDE57D9B91C83B /* Tab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68601CF3E6827AFAB9E783C /* Tab.swift */; };
+		04448C92AC5CB2353544049B /* StatsChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52077BF529C084B841CC0F46 /* StatsChartView.swift */; };
+		06B581366A36190E9F44B05A /* RecordsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC10CA9FF0210B51D5F060F7 /* RecordsViewModel.swift */; };
 		1D7DD784DA0C60556D04B487 /* MenuTemplateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB670E43771D3208B7FD2DF /* MenuTemplateSheet.swift */; };
 		1F329660C154E2196370D62F /* SleepRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171562AE2F6152870FD521A4 /* SleepRecord.swift */; };
 		21257451B0CBF18D80073ADA /* WeeklyMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCAA8182C3D3D66B7F10FA4 /* WeeklyMenuViewModel.swift */; };
 		30A010D6F1624F2A29D111D3 /* WeekCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BC5F341DEEAF38FD217CD3 /* WeekCalendarView.swift */; };
+		312AACF3E04A2D02F73720F2 /* RunningHistoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6908B908F105DFE59176A4 /* RunningHistoryList.swift */; };
 		3DB311A0352E874807F280CA /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC6B615920679A5B6425AAFA /* SettingsView.swift */; };
 		48E5757A14DA59F1CC8E4E95 /* RecordsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */; };
 		5987DF2D06FC24CCA287A431 /* TodayMenuCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8018D3B1B2E6494189418307 /* TodayMenuCard.swift */; };
@@ -24,6 +27,7 @@
 		9596D36AC457ECD9BE4FD2F5 /* RaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 699AB2DA19ED9D53CA7DCF57 /* RaceModel.swift */; };
 		A056B5CFE7FD070D67A41C14 /* GoalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C35D2135867741362E3AE23 /* GoalType.swift */; };
 		A7EE6972B24E14313836E96D /* RunningWorkout.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB96FA62E2AB87E4012C6E74 /* RunningWorkout.swift */; };
+		AA27724B88633D5CE1F260C3 /* SleepHistoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607D87C31C5D328D7FD3A049 /* SleepHistoryList.swift */; };
 		B133C2D3F032C11AB1069442 /* TrainingMenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862EA7FAA86C60FDDA949048 /* TrainingMenuModel.swift */; };
 		BC3A8373A1CE6681F0FF20F2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3FBAFFDFA992C9C292C673C7 /* Assets.xcassets */; };
 		C4121A826AB3F1954AACC2B5 /* DayMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B76891E8C7302E20BFD3F4E5 /* DayMenuCell.swift */; };
@@ -44,7 +48,9 @@
 		3DA138DAED0EEB89EF1ECC52 /* HealthKitService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitService.swift; sourceTree = "<group>"; };
 		3FBAFFDFA992C9C292C673C7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4FCAA8182C3D3D66B7F10FA4 /* WeeklyMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyMenuViewModel.swift; sourceTree = "<group>"; };
+		52077BF529C084B841CC0F46 /* StatsChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsChartView.swift; sourceTree = "<group>"; };
 		5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordsView.swift; sourceTree = "<group>"; };
+		607D87C31C5D328D7FD3A049 /* SleepHistoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SleepHistoryList.swift; sourceTree = "<group>"; };
 		60E1BFDF85EC77EAD3C6E91D /* MarathonTrainingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarathonTrainingApp.swift; sourceTree = "<group>"; };
 		63B550B305F6909BEBC11126 /* WeeklySummaryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklySummaryCard.swift; sourceTree = "<group>"; };
 		699AB2DA19ED9D53CA7DCF57 /* RaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RaceModel.swift; sourceTree = "<group>"; };
@@ -54,6 +60,7 @@
 		86EC631FD4930C1584D894B9 /* MarathonTraining.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MarathonTraining.entitlements; sourceTree = "<group>"; };
 		88CF801CE7ACCDEE315A8708 /* CountdownCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountdownCard.swift; sourceTree = "<group>"; };
 		8C96D31363F79F305E2F5541 /* TrainingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrainingType.swift; sourceTree = "<group>"; };
+		8F6908B908F105DFE59176A4 /* RunningHistoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningHistoryList.swift; sourceTree = "<group>"; };
 		953436DD6951BDD71CAC756E /* WeeklyMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyMenuView.swift; sourceTree = "<group>"; };
 		9E68531B5DC6DEDA0584A1CC /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		A68601CF3E6827AFAB9E783C /* Tab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tab.swift; sourceTree = "<group>"; };
@@ -61,6 +68,7 @@
 		B5018C41BB6D04354866DA7F /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		B76891E8C7302E20BFD3F4E5 /* DayMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayMenuCell.swift; sourceTree = "<group>"; };
 		BBB670E43771D3208B7FD2DF /* MenuTemplateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTemplateSheet.swift; sourceTree = "<group>"; };
+		BC10CA9FF0210B51D5F060F7 /* RecordsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordsViewModel.swift; sourceTree = "<group>"; };
 		BE149F2CC235729C2894B6D9 /* WeeklyGoalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyGoalModel.swift; sourceTree = "<group>"; };
 		D433E722CA64B2DF5ECD787E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DAC0CFB5CFE231C528687E2F /* LongTermGoalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongTermGoalModel.swift; sourceTree = "<group>"; };
@@ -172,6 +180,8 @@
 			isa = PBXGroup;
 			children = (
 				5A4935F7ED5DA0643B4ED755 /* RecordsView.swift */,
+				BC10CA9FF0210B51D5F060F7 /* RecordsViewModel.swift */,
+				CBD8EFBDCD4BEC3DAEC54611 /* Components */,
 			);
 			path = Records;
 			sourceTree = "<group>";
@@ -238,6 +248,16 @@
 				F56431ECF8DF3CECF3383E87 /* GoalsView.swift */,
 			);
 			path = Goals;
+			sourceTree = "<group>";
+		};
+		CBD8EFBDCD4BEC3DAEC54611 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				8F6908B908F105DFE59176A4 /* RunningHistoryList.swift */,
+				607D87C31C5D328D7FD3A049 /* SleepHistoryList.swift */,
+				52077BF529C084B841CC0F46 /* StatsChartView.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		D3A648F76330DAEF6E324CF8 /* Settings */ = {
@@ -354,9 +374,13 @@
 				1D7DD784DA0C60556D04B487 /* MenuTemplateSheet.swift in Sources */,
 				9596D36AC457ECD9BE4FD2F5 /* RaceModel.swift in Sources */,
 				48E5757A14DA59F1CC8E4E95 /* RecordsView.swift in Sources */,
+				06B581366A36190E9F44B05A /* RecordsViewModel.swift in Sources */,
+				312AACF3E04A2D02F73720F2 /* RunningHistoryList.swift in Sources */,
 				A7EE6972B24E14313836E96D /* RunningWorkout.swift in Sources */,
 				3DB311A0352E874807F280CA /* SettingsView.swift in Sources */,
+				AA27724B88633D5CE1F260C3 /* SleepHistoryList.swift in Sources */,
 				1F329660C154E2196370D62F /* SleepRecord.swift in Sources */,
+				04448C92AC5CB2353544049B /* StatsChartView.swift in Sources */,
 				02AB5B9810FDE57D9B91C83B /* Tab.swift in Sources */,
 				5987DF2D06FC24CCA287A431 /* TodayMenuCard.swift in Sources */,
 				B133C2D3F032C11AB1069442 /* TrainingMenuModel.swift in Sources */,

--- a/MarathonTraining/Presentation/Records/Components/RunningHistoryList.swift
+++ b/MarathonTraining/Presentation/Records/Components/RunningHistoryList.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// List of running workout history
+struct RunningHistoryList: View {
+    let workouts: [RunningWorkout]
+
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "M/d (E)"
+        return formatter
+    }()
+
+    var body: some View {
+        if workouts.isEmpty {
+            EmptyStateView(
+                icon: "figure.run",
+                title: "記録がありません",
+                message: "ランニングを記録すると\nここに表示されます"
+            )
+        } else {
+            LazyVStack(spacing: 8) {
+                ForEach(workouts) { workout in
+                    RunningWorkoutRow(workout: workout, dateFormatter: dateFormatter)
+                }
+            }
+        }
+    }
+}
+
+struct RunningWorkoutRow: View {
+    let workout: RunningWorkout
+    let dateFormatter: DateFormatter
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(dateFormatter.string(from: workout.startDate))
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Spacer()
+
+                Text(workout.formattedDuration)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 16) {
+                // Distance
+                HStack(spacing: 4) {
+                    Image(systemName: "figure.run")
+                        .foregroundStyle(.blue)
+                    Text(workout.formattedDistance)
+                        .font(.headline)
+                }
+
+                Divider()
+                    .frame(height: 20)
+
+                // Pace
+                HStack(spacing: 4) {
+                    Image(systemName: "speedometer")
+                        .foregroundStyle(.orange)
+                    Text(workout.formattedPace)
+                        .font(.subheadline)
+                }
+
+                if let hr = workout.formattedAverageHeartRate {
+                    Divider()
+                        .frame(height: 20)
+
+                    // Heart rate
+                    HStack(spacing: 4) {
+                        Image(systemName: "heart.fill")
+                            .foregroundStyle(.red)
+                        Text(hr)
+                            .font(.subheadline)
+                    }
+                }
+
+                Spacer()
+            }
+
+            if let calories = workout.formattedCalories {
+                Text(calories)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/MarathonTraining/Presentation/Records/Components/SleepHistoryList.swift
+++ b/MarathonTraining/Presentation/Records/Components/SleepHistoryList.swift
@@ -1,0 +1,165 @@
+import SwiftUI
+
+/// List of sleep record history
+struct SleepHistoryList: View {
+    let records: [SleepRecord]
+
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "M/d (E)"
+        return formatter
+    }()
+
+    var body: some View {
+        if records.isEmpty {
+            EmptyStateView(
+                icon: "bed.double",
+                title: "記録がありません",
+                message: "睡眠を記録すると\nここに表示されます"
+            )
+        } else {
+            LazyVStack(spacing: 8) {
+                ForEach(records) { record in
+                    SleepRecordRow(record: record, dateFormatter: dateFormatter)
+                }
+            }
+        }
+    }
+}
+
+struct SleepRecordRow: View {
+    let record: SleepRecord
+    let dateFormatter: DateFormatter
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(dateFormatter.string(from: record.date))
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+
+                Spacer()
+
+                // Sleep quality indicator
+                HStack(spacing: 4) {
+                    Image(systemName: qualityIcon)
+                        .foregroundStyle(qualityColor)
+                    Text(String(format: "%.0f点", record.sleepQualityScore))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            HStack(spacing: 16) {
+                // Total sleep
+                HStack(spacing: 4) {
+                    Image(systemName: "moon.zzz.fill")
+                        .foregroundStyle(.purple)
+                    Text(record.formattedTotalSleep)
+                        .font(.headline)
+                }
+
+                Divider()
+                    .frame(height: 20)
+
+                // Bed time
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("就寝")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(record.formattedBedTime)
+                        .font(.subheadline)
+                }
+
+                // Wake time
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("起床")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(record.formattedWakeTime)
+                        .font(.subheadline)
+                }
+
+                Spacer()
+            }
+
+            // Sleep stages
+            HStack(spacing: 12) {
+                SleepStageIndicator(
+                    label: "深い睡眠",
+                    duration: record.deepSleepDuration,
+                    color: .indigo
+                )
+
+                SleepStageIndicator(
+                    label: "レム睡眠",
+                    duration: record.remSleepDuration,
+                    color: .cyan
+                )
+
+                SleepStageIndicator(
+                    label: "コア睡眠",
+                    duration: record.coreSleepDuration,
+                    color: .purple
+                )
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var qualityIcon: String {
+        if record.sleepQualityScore >= 80 {
+            return "star.fill"
+        } else if record.sleepQualityScore >= 60 {
+            return "star.leadinghalf.filled"
+        } else {
+            return "star"
+        }
+    }
+
+    private var qualityColor: Color {
+        if record.sleepQualityScore >= 80 {
+            return .yellow
+        } else if record.sleepQualityScore >= 60 {
+            return .orange
+        } else {
+            return .secondary
+        }
+    }
+}
+
+struct SleepStageIndicator: View {
+    let label: String
+    let duration: TimeInterval
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 2) {
+                Circle()
+                    .fill(color)
+                    .frame(width: 8, height: 8)
+
+                Text(formattedDuration)
+                    .font(.caption)
+            }
+        }
+    }
+
+    private var formattedDuration: String {
+        let hours = Int(duration) / 3600
+        let minutes = (Int(duration) % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        } else {
+            return "\(minutes)m"
+        }
+    }
+}

--- a/MarathonTraining/Presentation/Records/Components/StatsChartView.swift
+++ b/MarathonTraining/Presentation/Records/Components/StatsChartView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import Charts
+
+/// Chart view for weekly distance stats
+struct WeeklyDistanceChart: View {
+    let data: [(date: Date, distance: Double)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("走行距離")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            if data.isEmpty {
+                Text("データがありません")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .frame(height: 150)
+                    .frame(maxWidth: .infinity)
+            } else {
+                Chart(data, id: \.date) { item in
+                    BarMark(
+                        x: .value("日付", item.date, unit: .day),
+                        y: .value("距離", item.distance)
+                    )
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [.blue, .cyan],
+                            startPoint: .bottom,
+                            endPoint: .top
+                        )
+                    )
+                    .cornerRadius(4)
+                }
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { value in
+                        if let date = value.as(Date.self) {
+                            AxisValueLabel {
+                                Text(dayLabel(for: date))
+                                    .font(.caption2)
+                            }
+                        }
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks { value in
+                        AxisValueLabel {
+                            if let distance = value.as(Double.self) {
+                                Text(String(format: "%.0f", distance))
+                                    .font(.caption2)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 150)
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    private func dayLabel(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ja_JP")
+        formatter.dateFormat = "E"
+        return formatter.string(from: date)
+    }
+}
+
+/// Summary stats card
+struct StatsSummaryCard: View {
+    let title: String
+    let value: String
+    let subtitle: String?
+    let icon: String
+    let color: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: icon)
+                    .foregroundStyle(color)
+                Text(title)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(value)
+                .font(.title2)
+                .fontWeight(.bold)
+
+            if let subtitle = subtitle {
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}

--- a/MarathonTraining/Presentation/Records/RecordsView.swift
+++ b/MarathonTraining/Presentation/Records/RecordsView.swift
@@ -1,11 +1,146 @@
 import SwiftUI
 
 struct RecordsView: View {
+    @State private var viewModel = RecordsViewModel()
+    @State private var healthKitService = HealthKitService()
+
     var body: some View {
-        Text("Records")
+        VStack(spacing: 0) {
+            // Tab picker
+            Picker("記録タイプ", selection: $viewModel.selectedTab) {
+                ForEach(RecordTab.allCases, id: \.self) { tab in
+                    Text(tab.displayName).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            // Date range picker
+            HStack {
+                Text("期間:")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                Picker("期間", selection: $viewModel.dateRange) {
+                    ForEach(DateRange.allCases, id: \.self) { range in
+                        Text(range.displayName).tag(range)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            // Content
+            ScrollView {
+                if viewModel.isLoading {
+                    ProgressView()
+                        .padding(.top, 40)
+                } else {
+                    VStack(spacing: 16) {
+                        switch viewModel.selectedTab {
+                        case .running:
+                            runningContent
+                        case .sleep:
+                            sleepContent
+                        }
+                    }
+                    .padding()
+                }
+
+                if let error = viewModel.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .padding()
+                }
+            }
+            .background(Color(.systemGroupedBackground))
+        }
+        .onChange(of: viewModel.dateRange) { _, newValue in
+            viewModel.setDateRange(newValue)
+        }
+        .refreshable {
+            await viewModel.loadData()
+        }
+        .task {
+            viewModel.configure(healthKitService: healthKitService)
+            await viewModel.loadData()
+        }
+    }
+
+    private var runningContent: some View {
+        VStack(spacing: 16) {
+            // Stats summary
+            HStack(spacing: 12) {
+                StatsSummaryCard(
+                    title: "総距離",
+                    value: String(format: "%.1f km", viewModel.totalDistance),
+                    subtitle: nil,
+                    icon: "figure.run",
+                    color: .blue
+                )
+
+                StatsSummaryCard(
+                    title: "平均ペース",
+                    value: formatPace(viewModel.averagePace),
+                    subtitle: nil,
+                    icon: "speedometer",
+                    color: .orange
+                )
+            }
+
+            // Chart
+            WeeklyDistanceChart(data: viewModel.dailyDistances)
+
+            // History list
+            RunningHistoryList(workouts: viewModel.runningWorkouts)
+        }
+    }
+
+    private var sleepContent: some View {
+        VStack(spacing: 16) {
+            // Stats summary
+            HStack(spacing: 12) {
+                StatsSummaryCard(
+                    title: "平均睡眠時間",
+                    value: formatDuration(viewModel.averageSleepDuration),
+                    subtitle: nil,
+                    icon: "moon.zzz.fill",
+                    color: .purple
+                )
+
+                StatsSummaryCard(
+                    title: "平均睡眠スコア",
+                    value: String(format: "%.0f点", viewModel.averageSleepQuality),
+                    subtitle: nil,
+                    icon: "star.fill",
+                    color: .yellow
+                )
+            }
+
+            // History list
+            SleepHistoryList(records: viewModel.sleepRecords)
+        }
+    }
+
+    private func formatPace(_ pace: Double) -> String {
+        guard pace > 0 else { return "-" }
+        let minutes = Int(pace)
+        let seconds = Int((pace - Double(minutes)) * 60)
+        return String(format: "%d:%02d/km", minutes, seconds)
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        let hours = Int(duration) / 3600
+        let minutes = (Int(duration) % 3600) / 60
+        return String(format: "%d時間%02d分", hours, minutes)
     }
 }
 
 #Preview {
-    RecordsView()
+    NavigationStack {
+        RecordsView()
+    }
 }

--- a/MarathonTraining/Presentation/Records/RecordsViewModel.swift
+++ b/MarathonTraining/Presentation/Records/RecordsViewModel.swift
@@ -62,13 +62,17 @@ final class RecordsViewModel {
 
         let calendar = Calendar.current
         let now = Date()
-        guard let startDate = calendar.date(byAdding: .day, value: -dateRange.days, to: now) else { return }
+        // Normalize to start of day to include full first day
+        guard let rawStartDate = calendar.date(byAdding: .day, value: -dateRange.days, to: now) else { return }
+        let startDate = calendar.startOfDay(for: rawStartDate)
+        // End date is end of current day
+        guard let endDate = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now)) else { return }
 
         do {
             try await healthKitService.requestAuthorization()
 
-            async let workoutsTask = healthKitService.fetchRunningWorkouts(from: startDate, to: now)
-            async let sleepTask = healthKitService.fetchSleepData(from: startDate, to: now)
+            async let workoutsTask = healthKitService.fetchRunningWorkouts(from: startDate, to: endDate)
+            async let sleepTask = healthKitService.fetchSleepData(from: startDate, to: endDate)
 
             runningWorkouts = try await workoutsTask
             sleepRecords = try await sleepTask

--- a/MarathonTraining/Presentation/Records/RecordsViewModel.swift
+++ b/MarathonTraining/Presentation/Records/RecordsViewModel.swift
@@ -1,0 +1,129 @@
+import Foundation
+import Observation
+
+/// Date range filter options
+enum DateRange: String, CaseIterable {
+    case week
+    case month
+    case threeMonths
+
+    var displayName: String {
+        switch self {
+        case .week: return "1週間"
+        case .month: return "1ヶ月"
+        case .threeMonths: return "3ヶ月"
+        }
+    }
+
+    var days: Int {
+        switch self {
+        case .week: return 7
+        case .month: return 30
+        case .threeMonths: return 90
+        }
+    }
+}
+
+/// Record tab selection
+enum RecordTab: String, CaseIterable {
+    case running
+    case sleep
+
+    var displayName: String {
+        switch self {
+        case .running: return "ランニング"
+        case .sleep: return "睡眠"
+        }
+    }
+}
+
+/// ViewModel for Records screen
+@Observable
+final class RecordsViewModel {
+    private var healthKitService: HealthKitService?
+
+    var selectedTab: RecordTab = .running
+    var dateRange: DateRange = .week
+    var runningWorkouts: [RunningWorkout] = []
+    var sleepRecords: [SleepRecord] = []
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    func configure(healthKitService: HealthKitService) {
+        self.healthKitService = healthKitService
+    }
+
+    @MainActor
+    func loadData() async {
+        guard let healthKitService = healthKitService else { return }
+
+        isLoading = true
+        errorMessage = nil
+
+        let calendar = Calendar.current
+        let now = Date()
+        guard let startDate = calendar.date(byAdding: .day, value: -dateRange.days, to: now) else { return }
+
+        do {
+            try await healthKitService.requestAuthorization()
+
+            async let workoutsTask = healthKitService.fetchRunningWorkouts(from: startDate, to: now)
+            async let sleepTask = healthKitService.fetchSleepData(from: startDate, to: now)
+
+            runningWorkouts = try await workoutsTask
+            sleepRecords = try await sleepTask
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    func setDateRange(_ range: DateRange) {
+        dateRange = range
+        Task {
+            await loadData()
+        }
+    }
+
+    // MARK: - Running Stats
+
+    var totalDistance: Double {
+        runningWorkouts.reduce(0) { $0 + $1.distanceInKm }
+    }
+
+    var totalDuration: TimeInterval {
+        runningWorkouts.reduce(0) { $0 + $1.duration }
+    }
+
+    var averagePace: Double {
+        guard totalDistance > 0 else { return 0 }
+        return (totalDuration / 60) / totalDistance
+    }
+
+    var dailyDistances: [(date: Date, distance: Double)] {
+        let calendar = Calendar.current
+        var distances: [Date: Double] = [:]
+
+        for workout in runningWorkouts {
+            let day = calendar.startOfDay(for: workout.startDate)
+            distances[day, default: 0] += workout.distanceInKm
+        }
+
+        return distances.map { ($0.key, $0.value) }.sorted { $0.date < $1.date }
+    }
+
+    // MARK: - Sleep Stats
+
+    var averageSleepDuration: TimeInterval {
+        guard !sleepRecords.isEmpty else { return 0 }
+        let total = sleepRecords.reduce(0) { $0 + $1.totalSleepDuration }
+        return total / Double(sleepRecords.count)
+    }
+
+    var averageSleepQuality: Double {
+        guard !sleepRecords.isEmpty else { return 0 }
+        let total = sleepRecords.reduce(0) { $0 + $1.sleepQualityScore }
+        return total / Double(sleepRecords.count)
+    }
+}


### PR DESCRIPTION
## Summary
- Add RecordsViewModel with date range filtering (1 week, 1 month, 3 months)
- Implement tab picker for running/sleep records
- Add RunningHistoryList showing distance, pace, heart rate
- Add SleepHistoryList showing sleep stages and quality score
- Add WeeklyDistanceChart using Charts framework
- Add StatsSummaryCard for displaying total stats
- Add pull-to-refresh support

## Test plan
- [ ] Verify tab switching between running and sleep
- [ ] Verify date range filtering works correctly
- [ ] Verify running history displays workout details
- [ ] Verify sleep history displays sleep stages
- [ ] Verify chart displays correctly with data

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)